### PR TITLE
Closed #6: 旋轉物件

### DIFF
--- a/PageComposer/Main.mm
+++ b/PageComposer/Main.mm
@@ -533,7 +533,13 @@ BOOL RunFile(istream& ist, NSString *overrideOutputPath)
             [NSGraphicsContext setCurrentContext:cocoagc];
             NSAffineTransform *xfrm = [NSAffineTransform transform];
             [xfrm scaleXBy: 1 yBy: -1];
-            [xfrm translateXBy: CGRectGetMinX(targetRect) yBy: -CGRectGetMaxY(targetRect)];
+            [xfrm translateXBy: CGRectGetMidX(targetRect) yBy: -CGRectGetMidY(targetRect)];
+            CGFloat centerRotationDegree = 0;
+            if ([settings objectForKey: @"CenterRotation"]) {
+                centerRotationDegree = [[settings objectForKey: @"CenterRotation"] floatValue];
+            }
+            [xfrm rotateByDegrees: -centerRotationDegree];
+            [xfrm translateXBy: -CGRectGetWidth(targetRect) / 2.0 yBy: -CGRectGetHeight(targetRect) / 2.0];
             
             if (clockwiseRotation || vertical) {
                 [xfrm rotateByDegrees: 90];

--- a/PageComposer/Main.mm
+++ b/PageComposer/Main.mm
@@ -406,8 +406,18 @@ BOOL RunFile(istream& ist, NSString *overrideOutputPath)
                     }
 					
                     CGContextSaveGState(context);
-
+                    CGFloat centerRotationDegree = 0;
+                    if ([settings objectForKey: @"CenterRotation"]) {
+                        centerRotationDegree = [[settings objectForKey: @"CenterRotation"] floatValue];
+                    }
+                    CGPoint center = CGPointMake(CGRectGetMidX(targetRect), CGRectGetMidY(targetRect));
+                    CGContextTranslateCTM(context, center.x, center.y);
+                    CGContextRotateCTM(context, centerRotationDegree * M_PI / 180.0);
+                    CGContextTranslateCTM(context, -CGRectGetWidth(targetRect)/2.0, -CGRectGetHeight(targetRect)/2.0);
+                    targetRect.origin = CGPointZero;
+                    
 					if (radius > 0) AddBorderRadiusPath(context, targetRect, radius);
+                    
                     cg.drawImage(sourceImage, targetRect);
 					CGContextRestoreGState(context);
                     CFRelease(sourceImage);

--- a/PageComposer/Test/rotate.pcd
+++ b/PageComposer/Test/rotate.pcd
@@ -1,0 +1,12 @@
+beginpdf 600 600
+
+simpleimage https://67.media.tumblr.com/3793b2c1fd80436127118786b9d3e483/tumblr_odd4e4efOo1qixdtpo1_540.jpg 163 100 274 400
+
+set CenterRotation 30
+simpleimage https://67.media.tumblr.com/3793b2c1fd80436127118786b9d3e483/tumblr_odd4e4efOo1qixdtpo1_540.jpg 163 100 274 400
+
+set CenterRotation 60
+simpleimage https://67.media.tumblr.com/3793b2c1fd80436127118786b9d3e483/tumblr_odd4e4efOo1qixdtpo1_540.jpg 163 100 274 400
+
+endpdf file:///tmp/preview.pdf
+

--- a/PageComposer/Test/textrotate.pcd
+++ b/PageComposer/Test/textrotate.pcd
@@ -1,0 +1,33 @@
+beginpdf 600 600
+
+simplecolor yellow 30 30 20 540
+
+set CenterRotation 45
+set FontSize 14
+set FontSizeCJK 14
+set Typeface "Helvetica"
+set TypefaceCJK "HiraginoSansGB-W3"
+set TextAlign center
+set Ligature 1
+set SymbolSubstitution "，。、；？！"
+set TypefaceSubstitution "STHeitiTC-Light"
+set FontSizeSubstitution 14pt
+vtext 30 30 20 540 白日依山盡，黃河入海流。
+
+
+simplecolor green 200 50 300 20
+
+set CenterRotation 60
+set FontSize 14
+set FontSizeCJK 14
+set Typeface "Helvetica"
+set TypefaceCJK "HiraginoSansGB-W3"
+set TextAlign center
+set Ligature 1
+set SymbolSubstitution "，。、；？！"
+set TypefaceSubstitution "STHeitiTC-Light"
+set FontSizeSubstitution 14pt
+text 200 50 300 20 白日依山盡，黃河入海流。
+
+endpdf file:///tmp/preview.pdf
+

--- a/PageComposer/Test/textrotate.pcd
+++ b/PageComposer/Test/textrotate.pcd
@@ -1,6 +1,10 @@
 beginpdf 600 600
 
-simplecolor yellow 30 30 20 540
+set CenterRotation 20
+simpleimage https://66.media.tumblr.com/6b461270e63a0e4c2791b94316fac540/tumblr_odxo58VTmm1qa6qfto1_1280.png 100 100 330 220
+
+set CenterRotation 45
+simplecolor yellow 130 30 20 540
 
 set CenterRotation 45
 set FontSize 14
@@ -12,10 +16,10 @@ set Ligature 1
 set SymbolSubstitution "，。、；？！"
 set TypefaceSubstitution "STHeitiTC-Light"
 set FontSizeSubstitution 14pt
-vtext 30 30 20 540 白日依山盡，黃河入海流。
+vtext 130 30 20 540 白日依山盡，黃河入海流。
 
-
-simplecolor green 200 50 300 20
+set CenterRotation 60
+simplecolor green 200 200 300 20
 
 set CenterRotation 60
 set FontSize 14
@@ -27,7 +31,7 @@ set Ligature 1
 set SymbolSubstitution "，。、；？！"
 set TypefaceSubstitution "STHeitiTC-Light"
 set FontSizeSubstitution 14pt
-text 200 50 300 20 白日依山盡，黃河入海流。
+text 200 200 300 20 欲窮千里目，更上一層樓。
 
 endpdf file:///tmp/preview.pdf
 


### PR DESCRIPTION
加入 `set CenterRotation 90` 這樣的設置。
可以 apply 到 image/text/rect(simplecolor) 上。
數值為逆時針旋轉角度。

範例請參閱 `PageComposer/Test/textrotate.pcd`。